### PR TITLE
fix(prescription): improve dispense type logic and date calculation

### DIFF
--- a/src/components/Patient/PatientPanel/AddEditPrescriptionUnit.vue
+++ b/src/components/Patient/PatientPanel/AddEditPrescriptionUnit.vue
@@ -1395,10 +1395,10 @@ const addPatientVisitDetail = async () => {
   } else if (curPatientVisitDetail.value.pack.packagedDrugs.length === 0) {
     submittingValidateDispense.value = false;
     alertError('Deve ter pelo menos um medicamento para efectuar a dispensa');
-  } else if (Number(curPatientVisitDetail.value.pack.weeksSupply) <= 0) {
+  } else if (Number(curPatientVisitDetail.value.pack.weeksSupply) < 0) {
     submittingValidateDispense.value = false;
     alertError(
-      'Por favor indicar o período para o qual pretende efectuar a dispensa de medicamento' +
+      'Por favor indicar o período para o qual pretende efectuar a dispensa de medicamento ' +
         props.identifier.service.code
     );
   } else if (

--- a/src/components/Patient/Prescription/PrescriptionDrugsListHeader.vue
+++ b/src/components/Patient/Prescription/PrescriptionDrugsListHeader.vue
@@ -212,9 +212,12 @@ const determineNextPickUpDate = (pickupDate, weeks) => {
   if (date.isValid(extractHyphenDateFromDMYConvertYMD(pickupDate))) {
     const newDate = getDateFromHyphenDDMMYYYY(pickupDate);
     let lostDays = parseInt((weeks / 4) * 2);
-    if (weeks <= 1) {
+    if (0 < weeks && weeks <= 1) {
       lostDays = 0;
+    } else if (weeks === 0) {
+      lostDays = 1;
     }
+
     const daysToAdd = parseInt(weeks * 7 + lostDays);
     nextPDate.value = getDDMMYYYFromJSDate(
       date.addToDate(newDate, { days: daysToAdd })

--- a/src/composables/prescription/dispenseType.ts
+++ b/src/composables/prescription/dispenseType.ts
@@ -1,4 +1,7 @@
 export function useDispenseType() {
+  function isDD(dispenseType: any) {
+    return dispenseType.code === 'DD';
+  }
   function isDN(dispenseType: any) {
     return dispenseType.code === 'DN';
   }
@@ -24,7 +27,9 @@ export function useDispenseType() {
   }
 
   function getRelatedWeeks(dispenseType: any) {
-    if (isDN(dispenseType)) {
+    if (isDD(dispenseType)) {
+      return 0;
+    } else if (isDN(dispenseType)) {
       return 1;
     } else if (isDM(dispenseType)) {
       return 4;
@@ -39,5 +44,5 @@ export function useDispenseType() {
     }
   }
 
-  return { isDS, isDB, isDM, isDT, isDA, getRelatedWeeks };
+  return { isDD, isDN, isDS, isDB, isDM, isDT, isDA, getRelatedWeeks };
 }

--- a/src/composables/prescription/prescribedDrugMethods.ts
+++ b/src/composables/prescription/prescribedDrugMethods.ts
@@ -8,7 +8,9 @@ export function usePrescribedDrug() {
   function getQtyPrescribed(prescribedDrug: any, weeks: any) {
     if (weeks === null || weeks === '') return 0;
     let lostDays = parseInt(String((weeks / 4) * 2));
-    if (weeks <= 1) lostDays = 0;
+    if (weeks === 0) lostDays = 1;
+    if (weeks === 1) lostDays = 0;
+
     const days = parseInt(String(weeks * 7 + lostDays));
 
     let qty = 0;

--- a/src/services/api/dispenseType/dispenseTypeService.ts
+++ b/src/services/api/dispenseType/dispenseTypeService.ts
@@ -119,7 +119,7 @@ export default {
   getAllFromDuration(weeks: number) {
     let dispenseTypeList = [];
 
-    if (weeks < 4) {
+    if (0 < weeks && weeks < 4) {
       dispenseTypeList = dispenseType
         .where('code', (value: string) => {
           return value === 'DN';
@@ -171,6 +171,13 @@ export default {
             value === 'DS' ||
             value === 'FRM'
           );
+        })
+        .orderBy('id', 'asc')
+        .get();
+    } else if (weeks === 0) {
+      dispenseTypeList = dispenseType
+        .where('code', (value: string) => {
+          return value === 'DD';
         })
         .orderBy('id', 'asc')
         .get();

--- a/src/services/api/duration/durationService.ts
+++ b/src/services/api/duration/durationService.ts
@@ -153,7 +153,7 @@ export default {
     return duration.getModel().$newInstance();
   },
   getAllFromStorage() {
-    return duration.all();
+    return duration.orderBy('weeks', 'asc').get();
   },
 
   getDurationByWeeks(weeksSuply: any) {


### PR DESCRIPTION
Refactor prescription dispensing logic to correctly handle 'DD' (Daily Dispense)  and 'DN' dispense types. This includes updating the calculation for  lost days, adjusting the weeks supply validation, and ensuring the  dispense type service returns the correct list based on the number of weeks.

- Add `isDD` helper to `useDispenseType` composable
- Update `getRelatedWeeks` to return 0 for 'DD' type
- Adjust `determineNextPickUpDate` and `getQtyPrescribed` to handle 0 weeks correctly
- Update `dispenseTypeService` to filter types based on weeks supply
- Fix validation in `AddEditPrescriptionUnit.vue` to allow 0 weeks
- Sort durations by weeks in `durationService`